### PR TITLE
fix: use defineConfig from eslint/config instead of .flat()

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from "eslint/config";
 import raycastConfig from "@raycast/eslint-config";
 
-export default raycastConfig.flat();
+export default defineConfig([...raycastConfig]);


### PR DESCRIPTION
## Summary
- Replaces `raycastConfig.flat()` with the standard ESLint v9 `defineConfig([...raycastConfig])` pattern
- Aligns with other extensions in the repo (e.g. `brew`, `base64`)

## Test plan
- [ ] Verify ESLint runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)